### PR TITLE
ci(frontend): generar env.js en cada deploy y no excluirlo con clean-slate (Opción B)

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -58,22 +58,22 @@ jobs:
           ls -la dist/frontend || true
           test -d dist/frontend/browser
 
-      - name: Check env.js presence on FTP server (informational)
+      - name: Crear env.js (runtime config)
+        shell: bash
         run: |
           set -e
-          SERVER="${{ secrets.FTP_HOST }}"
-          USER="${{ secrets.FTP_USERNAME }}"
-          PASS="${{ secrets.FTP_PASSWORD }}"
-          DIR="${{ secrets.FTP_REMOTE_DIR }}"
-          echo "Listing ${DIR} on ${SERVER} via FTP (to check env.js)"
-          # Try to list directory (may vary by server); ignore errors but print output if any
-          OUT=$(curl -s --list-only --disable-epsv --ftp-method nocwd -u "$USER:$PASS" "ftp://${SERVER}${DIR}" || true)
-          echo "$OUT"
-          if echo "$OUT" | grep -qE "(^|/)env\.js$|(^| )env\.js$|^env\.js$"; then
-            echo "env.js found. It will be preserved by deploy."
-          else
-            echo "env.js not found in ${DIR}. If you need runtime config, upload env.js (see frontend/public/env.example.js)."
-          fi
+          # Genera un archivo de runtime config dentro del build estático
+          mkdir -p dist/frontend/browser
+          cat > dist/frontend/browser/env.js << 'EOF'
+          window.__ENV__ = {
+            OPENAPI_URL: ${{ toJSON(vars.OPENAPI_URL) }},
+            API_URL: ${{ toJSON(vars.API_URL) }},
+            SENTRY_DSN: ${{ toJSON(secrets.SENTRY_DSN) }},
+            COMMIT_SHA: ${{ toJSON(github.sha) }}
+          };
+          EOF
+          echo "env.js generado en dist/frontend/browser/env.js"
+          ls -l dist/frontend/browser/env.js
 
       - name: Deploy via FTP/FTPS
         uses: SamKirkland/FTP-Deploy-Action@v4.3.5
@@ -91,8 +91,8 @@ jobs:
           # PRESERVANDO env.js (si existe en el hosting)
           dangerous-clean-slate: true
           exclude: |
-            env.js
-            **/env.js
+            **/.git*
+            **/.DS_Store
 
       # Alternative SFTP deploy (commented). Uncomment and remove the FTP step above if using SFTP.
       # - name: Deploy via SFTP

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -65,11 +65,10 @@ jobs:
           # Genera un archivo de runtime config dentro del build estático
           mkdir -p dist/frontend/browser
           cat > dist/frontend/browser/env.js << 'EOF'
-          window.__ENV__ = {
-            OPENAPI_URL: ${{ toJSON(vars.OPENAPI_URL) }},
-            API_URL: ${{ toJSON(vars.API_URL) }},
-            SENTRY_DSN: ${{ toJSON(secrets.SENTRY_DSN) }},
-            COMMIT_SHA: ${{ toJSON(github.sha) }}
+          // Archivo generado por CI en cada deploy (clean-slate)
+          // La app usa window.__env.API_BASE en tiempo de ejecución
+          window.__env = {
+            API_BASE: ${{ toJSON(vars.API_BASE) }}
           };
           EOF
           echo "env.js generado en dist/frontend/browser/env.js"


### PR DESCRIPTION
Este PR implementa la Opción B para resolver la pérdida de env.js:

- Genera dist/frontend/browser/env.js en el pipeline usando secretos/vars
- Mantiene dangerous-clean-slate: true
- Elimina env.js del exclude para que se suba en cada deploy

Impacto:
- Cada deploy limpia el servidor, pero env.js se vuelve a crear y subir
- Sigue apareciendo el mensaje de 'first publish', es esperado con clean-slate

Variables usadas:
- vars.OPENAPI_URL, vars.API_URL, secrets.SENTRY_DSN, github.sha

Asegurar:
- index.html referencie <script src="/env.js"></script> antes del bundle principal.
